### PR TITLE
Use the correct LinkedIn ID.

### DIFF
--- a/linkedin_server.js
+++ b/linkedin_server.js
@@ -1,17 +1,17 @@
 var OAuth = Package.oauth.OAuth;
 
-var urlUtil = Npm.require('url');
-
 OAuth.registerService('linkedin', 2, null, function(query) {
 
   var response = getTokenResponse(query);
   var accessToken = response.accessToken;
   var identity = getIdentity(accessToken);
-  var profileUrl = identity.siteStandardProfileRequest.url;
-  var urlParts = urlUtil.parse(profileUrl, true);
 
+  var id = identity.id;
+  if (!id) {
+    throw new Error("LinkedIn did not provide an id");    
+  }
   var serviceData = {
-    id: urlParts.query.id || Random.id(),
+    id: id,
     accessToken: accessToken,
     expiresAt: (+new Date) + (1000 * response.expiresIn)
   };


### PR DESCRIPTION
[LinkedIn recently changed the value of the id query
param](http://stackoverflow.com/questions/33014903/meteor-signin-with-linkedin-not-recognizing-existing-users)
in siteStandardProfileRequest so that it no longer matches the id field which is
returned. The query param should not be relied upon. This commit gets the id
from the id field instead.

NOTE: The IDs that used to be in the query param are different from both the
new IDs in the query param and the (correct) IDs in the id field. As a result,
existing users who log in with LinkedIn will get new accounts with or without
this commit. A separate change will be necessary to migrate existing users to
the new IDs. However, this change at least ensures that _new_ users will have
correct IDs so that there will be less of a mess to cleanup if LinkedIn changes
the query param id again.

NOTE #2: A forthcoming PR for pauli:accounts-linkedin will add a test for this
fix.
